### PR TITLE
add navibar title

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/PKCCrop/Classes/PKCCropHelper.swift
+++ b/PKCCrop/Classes/PKCCropHelper.swift
@@ -29,6 +29,7 @@ public enum PKCCropLineType{
 public class PKCCropHelper{
     public static let shared = PKCCropHelper()
 
+    public var titleText = ""
     public var isNavigationBarShow = false
     public var lineType: PKCCropLineType = .default
     public var maskAlpha: CGFloat = 0.4

--- a/PKCCrop/Classes/PKCCropHelper.swift
+++ b/PKCCrop/Classes/PKCCropHelper.swift
@@ -25,6 +25,9 @@ public enum PKCCropLineType{
     case show, hide, `default`
 }
 
+public enum PKCCropLineColor{
+    case white, lightGray
+}
 
 public class PKCCropHelper{
     public static let shared = PKCCropHelper()
@@ -32,6 +35,7 @@ public class PKCCropHelper{
     public var titleText = ""
     public var isNavigationBarShow = false
     public var lineType: PKCCropLineType = .default
+    public var lineColor: PKCCropLineColor = .white
     public var maskAlpha: CGFloat = 0.4
     public var barTintColor: UIColor = UIColor(red: 205/255, green: 205/255, blue: 205/255, alpha: 1)
     public var tintColor: UIColor = UIColor(red: 0, green: 0.4, blue: 1, alpha: 1)

--- a/PKCCrop/Classes/PKCCropLineView.swift
+++ b/PKCCrop/Classes/PKCCropLineView.swift
@@ -61,6 +61,16 @@ class PKCCropLineView: UIView {
     @IBOutlet private weak var minHeightConst: NSLayoutConstraint!
     @IBOutlet private weak var minWidthConst: NSLayoutConstraint!
     
+    @IBOutlet weak var topGuideLine: UIView!
+    @IBOutlet weak var leftGuideLine: UIView!
+    @IBOutlet weak var rightGuideLine: UIView!
+    @IBOutlet weak var bottomGuideLine: UIView!
+    
+    @IBOutlet weak var innerTopGuideLine: UIView!
+    @IBOutlet weak var innerLeftGuideLine: UIView!
+    @IBOutlet weak var innerRightGuideLine: UIView!
+    @IBOutlet weak var innerBottomGuideLine: UIView!
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.commonInitialization()
@@ -92,6 +102,30 @@ class PKCCropLineView: UIView {
 
         self.minHeightConst.constant = PKCCropHelper.shared.minSize
         self.minWidthConst.constant = PKCCropHelper.shared.minSize
+        
+        switch PKCCropHelper.shared.lineColor {
+        case PKCCropLineColor.white:
+            topGuideLine.backgroundColor = .white
+            leftGuideLine.backgroundColor = .white
+            rightGuideLine.backgroundColor = .white
+            bottomGuideLine.backgroundColor = .white
+            
+            innerTopGuideLine.backgroundColor = .white
+            innerLeftGuideLine.backgroundColor = .white
+            inngerRightGuideLine.backgroundColor = .white
+            innerBottomGuideLine.backgroundColor = .white
+            
+        case PKCCropLineColor.lightGray:
+            topGuideLine.backgroundColor = .lightGray
+            leftGuideLine.backgroundColor = .lightGray
+            rightGuideLine.backgroundColor = .lightGray
+            bottomGuideLine.backgroundColor = .lightGray
+            
+            innerTopGuideLine.backgroundColor = .lightGray
+            innerLeftGuideLine.backgroundColor = .lightGray
+            inngerRightGuideLine.backgroundColor = .lightGray
+            innerBottomGuideLine.backgroundColor = .lightGray
+        }
         
         DispatchQueue.main.async{
             self.leftTopButton.leftTop()

--- a/PKCCrop/Classes/PKCCropLineView.xib
+++ b/PKCCrop/Classes/PKCCropLineView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,11 +13,17 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PKCCropLineView" customModule="PKCCrop" customModuleProvider="target">
             <connections>
                 <outlet property="bottomConst" destination="xsh-9u-upz" id="Se4-5e-P6T"/>
+                <outlet property="bottomGuideLine" destination="1oH-YT-n4f" id="4kR-L0-wJV"/>
                 <outlet property="bottomTopButton" destination="Wdn-Ah-ji1" id="aiG-cl-Dbc"/>
                 <outlet property="centerButton" destination="C9z-kc-Bou" id="ITP-Vh-mby"/>
+                <outlet property="innerBottomGuideLine" destination="UmY-yI-nVY" id="Mfu-vC-9RB"/>
+                <outlet property="innerLeftGuideLine" destination="IGr-xc-XWU" id="rYg-X2-4Ua"/>
+                <outlet property="innerRightGuideLine" destination="8ws-d8-ciq" id="Ymg-cl-GWW"/>
+                <outlet property="innerTopGuideLine" destination="QlH-W1-5kC" id="Pme-ln-vtT"/>
                 <outlet property="leftBottomButton" destination="cju-Y0-kMc" id="4yL-LS-CYD"/>
                 <outlet property="leftButton" destination="vSf-NE-OdA" id="Ff5-Mx-QWr"/>
                 <outlet property="leftConst" destination="6xs-4g-QNQ" id="SlI-Kf-GAg"/>
+                <outlet property="leftGuideLine" destination="AxG-iS-vsj" id="BVH-TU-5Lf"/>
                 <outlet property="leftTopButton" destination="GHg-bw-M42" id="Ems-x4-m87"/>
                 <outlet property="limitBottomConst" destination="Xp7-jz-a1J" id="e2X-Un-DTT"/>
                 <outlet property="limitLeftConst" destination="VL0-dW-2Dn" id="ecK-Ez-dVL"/>
@@ -30,10 +36,12 @@
                 <outlet property="rightBottomButton" destination="ggB-px-seb" id="1an-rR-bIf"/>
                 <outlet property="rightButton" destination="O6B-GS-NvL" id="pyy-yw-xOB"/>
                 <outlet property="rightConst" destination="GIm-Z3-vfS" id="4C0-Gp-Z35"/>
+                <outlet property="rightGuideLine" destination="tsb-5Y-hKo" id="je2-nJ-7Rh"/>
                 <outlet property="rightTopButton" destination="MHM-MP-ko4" id="WN2-rO-JCq"/>
                 <outlet property="subLineView" destination="Sbf-jg-fQI" id="XGw-kc-9if"/>
                 <outlet property="topButton" destination="eOR-uP-E3y" id="x1v-bF-Ikj"/>
                 <outlet property="topConst" destination="lr4-0c-4Gq" id="APM-7O-zGh"/>
+                <outlet property="topGuideLine" destination="uVl-9l-v4p" id="VN2-ZR-TNo"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>

--- a/PKCCrop/Classes/PKCCropViewController.swift
+++ b/PKCCrop/Classes/PKCCropViewController.swift
@@ -97,6 +97,12 @@ public class PKCCropViewController: UIViewController {
     }
 
     private func initVars(){
+
+        //add navigation title when has navigationBar
+        if self.navigationController != nil || PKCCropHelper.shared.isNavigationBarShow {
+            self.title = PKCCropHelper.shared.titleText
+        }
+
         self.view.backgroundColor = .black
         self.maskView.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: PKCCropHelper.shared.maskAlpha)
         self.maskView.isUserInteractionEnabled = false


### PR DESCRIPTION
Why
1. for using navigationbar titleText. 
2.  if it's a white based photo,white guideLine so cloudy, so this library has to support the other color guideLine

Goals 
1. add navigationbar title.
2. add lightGray GuideLine.

Implementation Details 
.
